### PR TITLE
Remove AI icons and fix overly restrictive matching algorithm

### DIFF
--- a/lib/features/swipe/widgets/swipe_card.dart
+++ b/lib/features/swipe/widgets/swipe_card.dart
@@ -119,7 +119,7 @@ class _SwipeCardState extends State<SwipeCard> {
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            const Icon(Icons.auto_awesome_outlined, size: 16, color: AppColors.terracotta),
+                            const Icon(Icons.handshake_outlined, size: 16, color: AppColors.terracotta),
                             const SizedBox(width: 6),
                             Text(
                               '$_compatibility% match',

--- a/lib/home/dashboard_screen.dart
+++ b/lib/home/dashboard_screen.dart
@@ -174,7 +174,7 @@ class _DesktopDashboard extends ConsumerWidget {
               const SizedBox(width: 20),
               Expanded(
                 child: _StatCard(
-                  iconData: Icons.auto_awesome_outlined,
+                  iconData: Icons.trending_up,
                   iconColor: const Color(0xFFFBBF24),
                   value: avgCompat > 0 ? '$avgCompat%' : '--',
                   label: 'Avg. compatibility',
@@ -317,7 +317,7 @@ class _MobileDashboard extends ConsumerWidget {
               SizedBox(
                 width: (MediaQuery.of(context).size.width - 52) / 2,
                 child: _StatCard(
-                  iconData: Icons.auto_awesome_outlined,
+                  iconData: Icons.trending_up,
                   iconColor: const Color(0xFFFBBF24),
                   value: avgCompat > 0 ? '$avgCompat%' : '--',
                   label: 'Avg. compat.',

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -102,12 +102,18 @@ class FirestoreService {
       debugPrint('[SwipeDeck] excluding ${exclude.length} id(s): $exclude');
     }
 
-    final snap = await _users
+    // First try users who completed onboarding; fall back to all users if none
+    var snap = await _users
         .where('isProfileComplete', isEqualTo: true)
         .get();
 
+    if (snap.docs.where((doc) => !exclude.contains(doc.id)).isEmpty) {
+      if (kDebugMode) debugPrint('[SwipeDeck] no complete profiles outside exclusion set — falling back to all users');
+      snap = await _users.get();
+    }
+
     if (kDebugMode) {
-      debugPrint('[SwipeDeck] Firestore returned ${snap.docs.length} complete user(s)');
+      debugPrint('[SwipeDeck] Firestore returned ${snap.docs.length} user(s)');
       for (final d in snap.docs) {
         debugPrint('[SwipeDeck]   uid=${d.id} name=${d.data()['name']}');
       }
@@ -118,12 +124,11 @@ class FirestoreService {
         .map((doc) => UserModel.fromMap(doc.data(), doc.id))
         .where((candidate) {
           if (me == null) return true;
+          // Only apply the current user's own dealbreakers.
+          // Don't filter based on the candidate's dealbreakers — let them
+          // decide for themselves when they see our profile.
           if (MatchingService.violatesDealbreakers(candidate, me.dealbreakers)) {
             if (kDebugMode) debugPrint('[SwipeDeck] filtered ${candidate.name}: violates my dealbreakers');
-            return false;
-          }
-          if (MatchingService.violatesDealbreakers(me, candidate.dealbreakers)) {
-            if (kDebugMode) debugPrint('[SwipeDeck] filtered ${candidate.name}: I violate their dealbreakers');
             return false;
           }
           return true;


### PR DESCRIPTION
- Replace auto_awesome_outlined (AI sparkle) icons with handshake_outlined on swipe cards and trending_up on dashboard compatibility stats
- Remove reverse dealbreaker filtering that hid profiles from users whose dealbreakers the current user violated — let each user filter for themselves
- Add fallback to show all users when no profiles with isProfileComplete exist

